### PR TITLE
Support cover-compiled modules

### DIFF
--- a/src/horus.erl
+++ b/src/horus.erl
@@ -264,7 +264,9 @@ fun((#{calls := #{Call :: mfa() => true},
 %% `#horus_fun.debug_info' field. See {@link debug_info()}.</li>
 %% </ul>
 
--type debug_info() :: #{asm := asm()}.
+-type debug_info() :: #{fun_info := fun_info(),
+                        checksums := #{module() => binary()},
+                        asm := asm()}.
 %% Optional details added to the standalone function record.
 %%
 %% They are only added if the `debug_info' {@link options()} is set to true.
@@ -455,7 +457,7 @@ to_standalone_fun3(
   #state{fun_info = #{module := Module,
                       name := Name,
                       arity := Arity,
-                      type := Type},
+                      type := Type} = Info,
          options = Options} = State) ->
     case Type of
         local ->
@@ -499,7 +501,10 @@ to_standalone_fun3(
                                     false ->
                                         undefined;
                                     true ->
-                                        #{asm => Asm}
+                                        Checksums = State4#state.checksums,
+                                        #{fun_info => Info,
+                                          checksums => Checksums,
+                                          asm => Asm}
                                 end,
                     StandaloneFun = #horus_fun{
                                        module = GeneratedModuleName,

--- a/test/cover_compile.erl
+++ b/test/cover_compile.erl
@@ -1,0 +1,75 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright © 2023 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(cover_compile).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-include("src/horus_fun.hrl").
+
+cover_compilation_works_test() ->
+    Module = cover_compiled_mod,
+    Arg = arg,
+    Ret = Module:run(Arg),
+
+    Fun = fun Module:run/1,
+    {_, _, ModFile} = code:get_object_code(Module),
+    ?assertNot(cover:is_compiled(Module)),
+    InitialState = [{{Module, run, 1},
+                     {0, %% Covered
+                      2  %% Not covered
+                     }}],
+    Analysis = [{{Module, run, 1},
+                 {2, %% Covered
+                  0  %% Not covered
+                 }}],
+
+    %% We extract the regular module before we cover-compile it. We do this to
+    %% compare the standalone functions to make sure that their module names
+    %% are different because the code and the checksum are different.
+    StandaloneFun1 = horus:to_standalone_fun(Fun, #{debug_info => true}),
+    ?assertEqual(Ret, horus:exec(StandaloneFun1, [Arg])),
+
+    %% We ensure that cover-compilation works and that we get the expected
+    %% analysis results.
+    ?assertEqual({ok, Module}, cover:compile_beam(ModFile)),
+    ?assertEqual({file, ModFile}, cover:is_compiled(Module)),
+    ?assertEqual({ok, InitialState}, cover:analyse(Module)),
+
+    ?assertEqual(Ret, Module:run(Arg)),
+    ?assertEqual({ok, Analysis}, cover:analyse(Module)),
+
+    ok = cover:reset(Module),
+
+    %% Now, we try to extract the cover-compiled module. We then execute the
+    %% standalone function and verify the analysis again.
+    ?assertEqual({file, ModFile}, cover:is_compiled(Module)),
+    ?assertEqual({ok, InitialState}, cover:analyse(Module)),
+
+    StandaloneFun2 = horus:to_standalone_fun(Fun, #{debug_info => true}),
+    ?assertEqual(Ret, horus:exec(StandaloneFun2, [Arg])),
+    ?assertEqual({ok, Analysis}, cover:analyse(Module)),
+
+    ok = cover:reset(Module),
+
+    %% We finally compare the standalone functions: they must have a different
+    %% module name and checksum.
+    GeneratedName1 = StandaloneFun1#horus_fun.module,
+    GeneratedName2 = StandaloneFun2#horus_fun.module,
+    ?assertNotEqual(GeneratedName1, GeneratedName2),
+
+    Info1 = maps:get(fun_info, StandaloneFun1#horus_fun.debug_info),
+    Info2 = maps:get(fun_info, StandaloneFun2#horus_fun.debug_info),
+    ?assertEqual(Info1, Info2),
+
+    Checksums1 = maps:get(checksums, StandaloneFun1#horus_fun.debug_info),
+    Checksums2 = maps:get(checksums, StandaloneFun2#horus_fun.debug_info),
+    ?assertNotEqual(
+       maps:get(Module, Checksums1),
+       maps:get(Module, Checksums2)),
+
+    ok.

--- a/test/cover_compiled_mod.erl
+++ b/test/cover_compiled_mod.erl
@@ -1,0 +1,14 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright © 2023 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(cover_compiled_mod).
+
+-export([run/1]).
+
+run(Arg) ->
+    Hash = erlang:phash2(Arg),
+    {ok, Hash}.


### PR DESCRIPTION
### Why

Extracting a function from a cover-compiled module always worked. However, we missed the instructions added by `cover` because we took the module beam from the code server.

This means that executing a standalone function would not emit coverage information and thus the original source code would appear to never run.

### How

In this commit, if the module where the function to extract is defined is cover-compiled, we take the module beam from the ETS table where `cover` stores the cover-compiled modules.

This way, we ensure that the generated standalone function will contain any instructions added by `cover` and coverage information will be reported as expected.

Fixes #3.