### PR TITLE
Reconstruct meaningful stacktraces when a standalone fun raises an exception

### DIFF
--- a/src/horus_fun.hrl
+++ b/src/horus_fun.hrl
@@ -17,6 +17,7 @@
                     beam :: binary(),
                     arity :: arity(),
                     literal_funs :: [horus:horus_fun()],
+                    fun_name_mapping :: horus:fun_name_mapping(),
                     env :: list(),
                     debug_info :: horus:debug_info() | undefined}).
 

--- a/test/misuses.erl
+++ b/test/misuses.erl
@@ -90,6 +90,7 @@ exec_invalid_generated_module_test() ->
                        beam = <<"invalid">>,
                        arity = 0,
                        literal_funs = [],
+                       fun_name_mapping = #{},
                        env = []},
     ?assertError(
        ?horus_exception(


### PR DESCRIPTION
### Why

When a standalone function throws an exception, the stacktrace already shows the correct source file name and line number. However the function name makes no sense because it is a generated name. Thus it corresponds to no function in the indicated source file. This makes debugging more difficult.

### How

The returned standalone function now contains a mapping from the generated function name to its original MFA.

In `horus:exec/2`, we then catch the exception and reconstruct the actual stacktrace using this mapping.

Fixes #2.