### PR TITLE
Support `maybe ... end` expressions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Xref
         run: rebar3 xref
       - name: EUnit (unit tests)
-        run: rebar3 eunit --verbose --cover
+        run: env ERL_FLAGS='-enable-feature maybe_expr' rebar3 eunit --verbose --cover
 
       - name: Dialyzer
         if: ${{ matrix.otp_version == env.RUN_DIALYZER_ON_OTP_RELEASE && matrix.os == 'ubuntu-latest' }}

--- a/src/horus.erl
+++ b/src/horus.erl
@@ -2656,6 +2656,9 @@ pass2_process_instruction(
   {loop_rec, _, _} = Instruction, State) ->
     replace_label(Instruction, 2, State);
 pass2_process_instruction(
+  {loop_rec_end, _} = Instruction, State) ->
+    replace_label(Instruction, 2, State);
+pass2_process_instruction(
   {move, {atom, ?MOD_FOR_MODULE_INFO_FUN}, _} = Instruction,
   #state{mfa_in_progress = {?MOD_FOR_MODULE_INFO_FUN, module_info, _Arity},
          generated_module_name = GeneratedModuleName}) ->


### PR DESCRIPTION
`horus` needs to process the `loop_rec_end` instruction to fix the jump label. Otherwise, `maybe` doesn't seem to introduce new instructions.

However, this expression is introduced in Erlang 25 and is disabled by default. This means that:

1. We need to turn on a compiler flag. This can be done using the `-feature().` directive. This directive is behind a check of the version of Erlang because it won't compile on Erlang 24.

2. We need to turn on the same flag at runtime. Unfortunately Rebar doesn't provide any support for that... The flag must be set manually using the `$ERL_FLAGS` environment variable. This is what we do in the GitHub Actions workflow configuration file.

Fixed #6.