### PR TITLE
include/horus.hrl: Fix `?IS_HORUS_STANDALONE_FUN ` macro

### DIFF
--- a/include/horus.hrl
+++ b/include/horus.hrl
@@ -13,7 +13,7 @@
 
 -define(IS_HORUS_STANDALONE_FUN(Fun),
         (is_tuple(Fun) andalso
-         size(Fun) =:= 7 andalso
+         size(Fun) =:= 8 andalso
          element(1, Fun) =:= horus_fun)).
 
 -define(IS_HORUS_STANDALONE_FUN(Fun, Arity),

--- a/test/macros.erl
+++ b/test/macros.erl
@@ -1,0 +1,59 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright © 2023 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(macros).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-include("include/horus.hrl").
+-include("test/helpers.hrl").
+
+is_horus_fun_test() ->
+    Fun = fun() -> ok end,
+    ?assert(?IS_HORUS_FUN(Fun)),
+
+    StandaloneFun = horus:to_standalone_fun(Fun),
+    ?assertStandaloneFun(StandaloneFun),
+    ?assert(?IS_HORUS_FUN(StandaloneFun)),
+
+    ?assertNot(?IS_HORUS_FUN(not_a_horus_fun)).
+
+is_standalone_horus_fun_test() ->
+    Fun = fun() -> ok end,
+    ?assertNot(?IS_HORUS_STANDALONE_FUN(Fun)),
+
+    StandaloneFun = horus:to_standalone_fun(Fun),
+    ?assertStandaloneFun(StandaloneFun),
+    ?assert(?IS_HORUS_STANDALONE_FUN(StandaloneFun)),
+
+    ?assertNot(?IS_HORUS_STANDALONE_FUN(not_a_horus_fun)).
+
+is_standalone_horus_fun_arity_test() ->
+    Fun = fun() -> ok end,
+    ?assertNot(?IS_HORUS_STANDALONE_FUN(Fun, 0)),
+
+    StandaloneFun = horus:to_standalone_fun(Fun),
+    ?assertStandaloneFun(StandaloneFun),
+    ?assert(?IS_HORUS_STANDALONE_FUN(StandaloneFun, 0)),
+    ?assertNot(?IS_HORUS_STANDALONE_FUN(StandaloneFun, 1)),
+
+    ?assertNot(?IS_HORUS_STANDALONE_FUN(not_a_horus_fun, 0)).
+
+standalone_horus_arity_test() ->
+    Fun = fun() -> ok end,
+    ?assertError(
+       badarg,
+       ?HORUS_STANDALONE_FUN_ARITY(helpers:ensure_not_optimized(Fun))),
+
+    StandaloneFun = horus:to_standalone_fun(Fun),
+    ?assertStandaloneFun(StandaloneFun),
+    ?assertEqual(0, ?HORUS_STANDALONE_FUN_ARITY(StandaloneFun)),
+
+    ?assertError(
+       badarg,
+       ?HORUS_STANDALONE_FUN_ARITY(
+          helpers:ensure_not_optimized(not_a_horus_fun))).


### PR DESCRIPTION
After a new field was added to the `#horus_fun{}` record, I forgot to update the `?IS_HORUS_STANDALONE_FUN{}` macros accordingly.

This bug fix comes with a testsuite to make sure this will never happen again.