### PR TITLE
Support argument lists in stacktraces

### DIFF
--- a/src/horus.erl
+++ b/src/horus.erl
@@ -1066,8 +1066,17 @@ reconstruct_original_stracktrace(
   Stacktrace) ->
     lists:map(
       fun
+          ({Module, Name, Args, Extra})
+            when GeneratedModuleName =:= Module andalso is_list(Args) ->
+              Arity = length(Args),
+              {RealModule, RealName, RealArity} =
+              maps:get({Name, Arity}, FunNameMapping),
+
+              RealArgs = lists:sublist(Args, RealArity),
+              ?assertEqual(RealArity, length(RealArgs)),
+              {RealModule, RealName, RealArgs, Extra};
           ({Module, Name, Arity, Extra})
-            when GeneratedModuleName =:= Module ->
+            when GeneratedModuleName =:= Module andalso is_integer(Arity) ->
               {RealModule, RealName, RealArity} =
               maps:get({Name, Arity}, FunNameMapping),
 


### PR DESCRIPTION
Sometimes, a stacktrace frame will contain the actual list of arguments to a function instead of just its arity. We need to transfer this list of arguments to the reconstructed stacktrace.

We take a sublist of the arguments correpsonding to the arity of the original function. This is required because the extracted standalone function may take more arguments to take its environment into account. Arguments from the environment are therefore discarded.