### PR TITLE
Avoid hammerring the Code server

### DIFF
--- a/test/is_module_loaded.erl
+++ b/test/is_module_loaded.erl
@@ -1,0 +1,19 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright © 2023 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(is_module_loaded).
+
+-include_lib("eunit/include/eunit.hrl").
+
+on_a_loaded_module_test() ->
+    _ = lists:module_info(),
+    ?assert(horus_utils:is_module_loaded(lists)).
+
+on_a_missing_module_test() ->
+    Module = 'non_existing_module!',
+    ?assertError(undef, Module:module_info()),
+    ?assertNot(horus_utils:is_module_loaded(Module)).


### PR DESCRIPTION
### Why

When we are about to execute a standalone function, we first need to load the module. This is a synchronous call to the Code server.

So far, we checked that the module was already loaded using `code:is_loaded/1` before doing that to avoid too many useless calls to the Code server.

Unfortunately, up to Erlang/OTP 25, `code:is_loaded/1` is a synchronous call too! It is changed to an ETS query in Erlang/OTP 26, but before that, it remains an expansive and contentious call. If the same standalone function is executed concurrently a lot of time simultaneously, we end up spamming the Code server with a boat load of "is loaded" queries.

### What

To solve the problem, we introduce a `horus_utils:is_module_loaded/1` helper. On Erlang/OTP 26+, we call `code:is_loaded/1`. However on Erlang/OTP 25 and before, we replace that with a test of `erlang:get_module_info/2`, the function underneath any `Module:module_info/1` calls.

This way, it's a relatively cheap way of checking that the module is loaded.

At the same time, we acquire a lock around that module load code to make sure there is only a single attempt to load the module and concurrent processes will stop at "is loaded".