### PR TITLE
GitHub Actions: Test against Erlang/OTP 26 stable release

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,19 +11,19 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: [24, 25, 26.0-rc2]
+        otp_version: [24, 25, 26]
         os: [ubuntu-latest, windows-latest]
         exclude:
           # `ct_slave` fails to start Erlang nodes on Windows with Erlang 24.
           - otp_version: 24
             os: windows-latest
-          # The download for 26.0-rc2 currently hangs for 30min+ for Windows
-          # builds.
-          - otp_version: 26.0-rc2
+          # setup-beam currently hangs for 30+ minutes for Windows builds and
+          # Erlang/OTP 26.0.
+          - otp_version: 26
             os: windows-latest
 
     env:
-      RUN_DIALYZER_ON_OTP_RELEASE: 25
+      RUN_DIALYZER_ON_OTP_RELEASE: 26
 
     steps:
       - uses: actions/checkout@v3

--- a/src/horus.erl
+++ b/src/horus.erl
@@ -278,7 +278,8 @@ fun((#{calls := #{Call :: mfa() => true},
 -export_type([horus_fun/0,
               options/0,
               fun_name_mapping/0,
-              debug_info/0]).
+              debug_info/0,
+              beam_instr/0]).
 
 -type all_calls_map() :: #{mfa() => true}.
 %% The `all_calls' map, used to calls made by the extracted function and all

--- a/test/misuses.erl
+++ b/test/misuses.erl
@@ -13,7 +13,9 @@
 -include("src/horus_fun.hrl").
 
 -dialyzer([{no_missing_calls,
-            [unknown_function_1_test/0,
+            [unknown_module_1_test/0,
+             unknown_module_2_test/0,
+             unknown_function_1_test/0,
              unknown_function_2_test/0,
              unexported_function_1_test/0,
              unexported_function_2_test/0]},


### PR DESCRIPTION
We also run Dialyzer from Erlang/OTP 26.

There is still an issue with setup-beam which prevents us from testing with Erlang/OTP 26 on Windows...