### PR TITLE
horus.app: Add `erts` to application dependencies

### DIFF
--- a/src/horus.app.src
+++ b/src/horus.app.src
@@ -7,7 +7,8 @@
   %% Pay attention to links in particular.
   {vsn, "0.2.3"},
   {applications,
-   [kernel,
+   [erts,
+    kernel,
     stdlib,
     compiler,
     tools %% To support cover-compiled modules.


### PR DESCRIPTION
### Why

Horus relies on the availability of `erts` to initialize the list of modules to skip when it needs to decide if a call should be followed to extract a function or if the call should be preserved as is.

It already depends on `kernel` and `stdlib` for instance. I assumed that `erts` was implicit as I don't see how Erlang can work without it. It looks like if `erts` is not included explicitly in an Erlang release file or in the applications it bundles, it is excluded from the release (the `erts` Erlang application, not the actual runtime). This breaks Horus because it won't know about e.g. the `erlang` module and will try and fail to extract functions from that module.

Fixes #14.