### PR TITLE
Unwrap type-tagged registers for `update_record/5` type hint

### DIFF
--- a/src/horus.erl
+++ b/src/horus.erl
@@ -1704,8 +1704,9 @@ pass1_process_instructions(
   State,
   Result) ->
     State1 = ensure_instruction_is_permitted(Instruction, State),
+    Src1 = get_reg_from_type_tagged_beam_register(Src),
     Type = {t_tuple, Size, true, #{}},
-    VarInfo = {var_info, Src, [{type, Type}]},
+    VarInfo = {var_info, Src1, [{type, Type}]},
     Comment = {'%', VarInfo},
     pass1_process_instructions(Rest, State1, [Instruction, Comment | Result]);
 

--- a/test/erlang_records.erl
+++ b/test/erlang_records.erl
@@ -12,17 +12,19 @@
 -include("test/helpers.hrl").
 
 -record(my_record, {field}).
+-record(pair, {a, b}).
 
 create_record_test() ->
-    StandaloneFun = ?make_standalone_fun(#my_record{field = ok}),
+    Field = helpers:ensure_not_optimized(ok),
+    StandaloneFun = ?make_standalone_fun(#my_record{field = Field}),
     ?assertStandaloneFun(StandaloneFun),
-    ?assertEqual(#my_record{field = ok}, horus:exec(StandaloneFun, [])).
+    ?assertEqual(#my_record{field = Field}, horus:exec(StandaloneFun, [])).
 
 update_record_test() ->
-    Record = helpers:ensure_not_optimized(#my_record{field = 1}),
-    StandaloneFun = ?make_standalone_fun(Record#my_record{field = 2}),
+    Record = helpers:ensure_not_optimized(#pair{a = 123, b = 456}),
+    StandaloneFun = ?make_standalone_fun(Record#pair{a = 789}),
     ?assertStandaloneFun(StandaloneFun),
-    ?assertEqual(#my_record{field = 2}, horus:exec(StandaloneFun, [])).
+    ?assertEqual(#pair{a = 789, b = 456}, horus:exec(StandaloneFun, [])).
 
 match_record_test() ->
     Record = helpers:ensure_not_optimized(#my_record{field = ok}),


### PR DESCRIPTION
OTP 27.0-rc1 passes type-tagged registers in the `update_record/5` instruction. `var_info` comments only support regular registers so we need to unwrap the type tag.

The existing `update_record_test/0` EUnit case can produce an `update_record/5` but it currently only uses a `move/2` because the compiler is smart enough to see that the whole record is being replaced in the update. We can confuse the compiler a little by using a record with more fields, masking the values in those fields and then only updating one of the fields.