### PR TITLE
horus.app: Include license files correctly

### DIFF
--- a/src/horus.app.src
+++ b/src/horus.app.src
@@ -16,7 +16,7 @@
    ]},
   {env, [{skip_collection_froms_apps, []}]},
   {files, [
-    "README.md", "LICENSE", "mix.exs",
+    "README.md", "LICENSE-Apache-2.0", "LICENSE-MPL-2.0", "mix.exs",
     "rebar.config", "rebar.lock", "src", "include", "priv"]},
   {modules, []},
   {licenses, ["Apache-2.0", "MPL-2.0"]},


### PR DESCRIPTION
When the files are missing, it will break certain steps in the RabbitMQ Bazel build.