### PR TITLE
test/cached_extractions.erl: Ignore compile:forms/2-related Dialyzer errors

### DIFF
--- a/test/cached_extractions.erl
+++ b/test/cached_extractions.erl
@@ -11,6 +11,9 @@
 
 -include("test/helpers.hrl").
 
+-dialyzer({nowarn_function, [my_fun_module/1,
+                             modified_module_causes_cache_miss_test/0]}).
+
 local_fun_test() ->
     Fun = fun() -> ok end,
     StandaloneFun1 = horus:to_standalone_fun(Fun),


### PR DESCRIPTION
## Why

What I considered a fix to the `compile:forms/2` function was accepted in erlang/otp#5293 and available in Erlang/OTP 25.0+. However, this change was reverted in Erlang/OTP 27.0. I don't know the reason as of this writing.

Dialyzer in Erlang/OTP 27.0 also improved and now, it is not pleased by the way we use `compile:forms/2`, directly passing assembler.

## How

Let's ignore this Dialyzer error, like we ignore it already in `horus`.