### PR TITLE
test/cover_compile.erl: Adapt testing to Erlang/OTP 27's native coverage support

### DIFF
--- a/src/horus.erl
+++ b/src/horus.erl
@@ -59,6 +59,7 @@
 -include_lib("stdlib/include/assert.hrl").
 
 -include("include/horus.hrl").
+-include("src/horus_cover.hrl").
 -include("src/horus_fun.hrl").
 -include("src/horus_error.hrl").
 
@@ -323,19 +324,6 @@ fun((#{calls := #{Call :: mfa() => true},
 %% exception.
 
 -define(SF_ENTRYPOINT, run).
-
--if(?OTP_RELEASE >= 27).
--define(IF_NATIVE_COVERAGE_IS_SUPPORTED(IfSupportedBlock, ElseBlock),
-        (case code:coverage_support() of
-             true ->
-                 IfSupportedBlock;
-             false ->
-                 ElseBlock
-         end)).
--else.
--define(IF_NATIVE_COVERAGE_IS_SUPPORTED(_IfSupportedBlock, ElseBlock),
-        (ElseBlock)).
--endif.
 
 -spec to_standalone_fun(Fun) -> StandaloneFun when
       Fun :: fun(),

--- a/src/horus_cover.hrl
+++ b/src/horus_cover.hrl
@@ -1,0 +1,20 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright © 2024 Broadcom. All Rights Reserved. The term "Broadcom" refers
+%% to Broadcom Inc. and/or its subsidiaries.
+%%
+
+-if(?OTP_RELEASE >= 27).
+-define(IF_NATIVE_COVERAGE_IS_SUPPORTED(IfSupportedBlock, ElseBlock),
+        (case code:coverage_support() of
+             true ->
+                 IfSupportedBlock;
+             false ->
+                 ElseBlock
+         end)).
+-else.
+-define(IF_NATIVE_COVERAGE_IS_SUPPORTED(_IfSupportedBlock, ElseBlock),
+        (ElseBlock)).
+-endif.


### PR DESCRIPTION
## Why

When native coverage support is enabled, the standalone function's module won't update the initial module(s) counters.

## How

The assertions are skipped. The testcases are kind of useless when native coverage support is enabled.