### PR TITLE
GitHub Actions: Test against Erlang/OTP 27

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -14,8 +14,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: 25
-          rebar3-version: '3.18.0'
+          otp-version: 27
+          rebar3-version: '3.23.0'
 
       - name: Change doc version to "Development branch"
         run: sed -E -i -e 's/^@version.*/@version Development branch/' doc/overview.edoc

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: [24, 25, 26]
+        otp_version: [24, 25, 26, 27]
         os: [ubuntu-latest, windows-latest]
         exclude:
           # `ct_slave` fails to start Erlang nodes on Windows with Erlang 24.
@@ -23,7 +23,7 @@ jobs:
             os: windows-latest
 
     env:
-      RUN_DIALYZER_ON_OTP_RELEASE: 26
+      RUN_DIALYZER_ON_OTP_RELEASE: 27
 
     steps:
       - uses: actions/checkout@v4
@@ -31,7 +31,7 @@ jobs:
         id: install-erlang
         with:
           otp-version: ${{matrix.otp_version}}
-          rebar3-version: '3.20.0'
+          rebar3-version: '3.23.0'
 
       - name: Restore Dialyzer PLT files from cache
         uses: actions/cache@v4


### PR DESCRIPTION
We also use that latest version to build the docs.

This requires the bump of Rebar from 3.20.0 to 3.23.0.