### PR TITLE
GitHub Actions: Test against Erlang/OTP 28

### DIFF
--- a/.github/workflows/test-and-release.yaml
+++ b/.github/workflows/test-and-release.yaml
@@ -9,8 +9,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  REBAR_VERSION: '3.23.0'
-  LATEST_ERLANG_VERSION: '27'
+  REBAR_VERSION: '3.25.1'
+  LATEST_ERLANG_VERSION: '28'
 
 jobs:
   # `env_to_output` works around a limitation of GitHub Actions that prevents

--- a/.github/workflows/test-job.yaml
+++ b/.github/workflows/test-job.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        otp_version: ['25', '26', '27']
+        otp_version: ['26', '27', '28']
         os: [ubuntu-latest, windows-latest]
 
     steps:

--- a/test/nested_funs.erl
+++ b/test/nested_funs.erl
@@ -148,7 +148,7 @@ multiple_nested_higher_order_functions_test() ->
 
     Sets = sets:from_list([a, b]),
     Ret2 = Ret1(Sets, path, change),
-    ?assertEqual([{change, {path, a}}, {change, {path, b}}], Ret2).
+    ?assertEqual([{change, {path, a}}, {change, {path, b}}], lists:sort(Ret2)).
 
 projection_fun_for_sets(MapFun) ->
     ChangesFromSet =


### PR DESCRIPTION
While here, bump Rebar version from 3.23.0 to 3.25.1. Stop testing against Erlang/OTP 25 at the same time because Rebar 3.25.x is compiled with Erlang/OTP 26 and thus fails to run with version 25.

**V2**: Adapt the `nested_funs:multiple_nested_higher_order_functions_test/0` test case to the change of behaviour if `sets:fold/3`. There is no problem with `sets`, it was just a mistake of the testcase to rely on the order the set elements are evaluated in.