### PR TITLE
Implement lazy compilation of standalone functions

### DIFF
--- a/src/horus.erl
+++ b/src/horus.erl
@@ -67,12 +67,15 @@
 -export([to_standalone_fun/1,
          to_standalone_fun/2,
          to_fun/1,
+         uses_lazy_compilation/1,
          exec/2]).
 
 %% For internal use only.
 -export([override_object_code/2,
          forget_overridden_object_code/1,
-         do_get_object_code/1]).
+         do_get_object_code/1,
+         is_standalone_fun_loaded/1,
+         unload_standalone_fun/1]).
 
 -ifdef(TEST).
 -export([standalone_fun_cache_key/5,
@@ -251,7 +254,8 @@ fun((#{calls := #{Call :: mfa() => true},
                      is_standalone_fun_still_needed =>
                      is_standalone_fun_still_needed_fun(),
                      add_module_info => boolean(),
-                     debug_info => boolean()}.
+                     debug_info => boolean(),
+                     lazy_compilation => boolean()}.
 %% Options to tune the extraction of an anonymous function.
 %%
 %% <ul>
@@ -268,6 +272,9 @@ fun((#{calls := #{Call :: mfa() => true},
 %% (about 140 bytes). Default is true.</li>
 %% <li>`debug_info': a boolean to indicate if details should be added to the
 %% `#horus_fun.debug_info' field. See {@link debug_info()}.</li>
+%% <li>`lazy_compilation': a boolean to indicate if the generated module is
+%% compiled at extraction time (`false', the default) or at execution time
+%% (`true').</li>
 %% </ul>
 
 -type debug_info() :: #{fun_info := fun_info(),
@@ -503,7 +510,15 @@ to_standalone_fun3(
                     LiteralFuns = maps:values(LiteralFuns0),
 
                     {ok, Asm, FunNameMapping} = pass2(State4),
-                    {GeneratedModuleName, Beam} = compile(Asm),
+
+                    {GeneratedModuleName, AsmOrBeam} = (
+                                            case Options of
+                                                #{lazy_compilation := true} ->
+                                                    GMN = element(1, Asm),
+                                                    {GMN, Asm};
+                                                _ ->
+                                                    compile(Asm)
+                                            end),
 
                     DebugInfo = case maps:get(debug_info, Options, false) of
                                     false ->
@@ -516,7 +531,7 @@ to_standalone_fun3(
                                 end,
                     StandaloneFun = #horus_fun{
                                        module = GeneratedModuleName,
-                                       beam = Beam,
+                                       beam = AsmOrBeam,
                                        arity = Arity,
                                        literal_funs = LiteralFuns,
                                        fun_name_mapping = FunNameMapping,
@@ -757,6 +772,23 @@ extract_module_info_functions(State) ->
 
 should_generate_module_info_functions(#state{options = Options}) ->
     maps:get(add_module_info, Options, true).
+
+-spec uses_lazy_compilation(StandaloneFun) -> UsesLazyCompilation when
+      StandaloneFun :: horus_fun(),
+      UsesLazyCompilation :: boolean().
+%% @doc Returns if the given standalone function uses lazy compilation.
+%%
+%% @param StandaloneFun the extracted function as returnet by {@link
+%% to_standalone/2}.
+%%
+%% @returns the fact the standalone function uses lazy compilation or not.
+
+uses_lazy_compilation(#horus_fun{beam = Beam}) when is_binary(Beam) ->
+    false;
+uses_lazy_compilation(#horus_fun{beam = Asm}) when is_tuple(Asm) ->
+    true;
+uses_lazy_compilation(Fun) when is_function(Fun) ->
+    false.
 
 -spec compile(Asm) -> {Module, Beam} when
       Asm :: asm(), %% FIXME: compile:forms/2 is incorrectly specified.
@@ -1041,7 +1073,7 @@ exec(Fun, Args) ->
 %% @private
 
 load_standalone_fun(
-  #horus_fun{module = Module, beam = Beam} = StandaloneFun) ->
+  #horus_fun{module = Module, beam = AsmOrBeam} = StandaloneFun) ->
     case horus_utils:is_module_loaded(Module) of
         true ->
             ok;
@@ -1053,6 +1085,13 @@ load_standalone_fun(
                     global:del_lock(Lock, [node()]),
                     ok;
                 false ->
+                    Beam = if
+                               is_tuple(AsmOrBeam) ->
+                                   {Module, Beam0} = compile(AsmOrBeam),
+                                   Beam0;
+                               is_binary(AsmOrBeam) ->
+                                   AsmOrBeam
+                           end,
                     Ret = code:load_binary(Module, ?MODULE_STRING, Beam),
                     global:del_lock(Lock, [node()]),
                     case Ret of
@@ -1066,6 +1105,39 @@ load_standalone_fun(
                     end
             end
     end.
+
+-spec is_standalone_fun_loaded(StandaloneFun) -> IsLoaded when
+      StandaloneFun :: horus_fun(),
+      IsLoaded :: boolean().
+%% @doc Indicates in the module behind the given standalone function is already
+%% loaded or not.
+%%
+%% @private
+
+is_standalone_fun_loaded(#horus_fun{module = Module}) ->
+    horus_utils:is_module_loaded(Module);
+is_standalone_fun_loaded(Function) when is_function(Function) ->
+    false.
+
+-spec unload_standalone_fun(StandaloneFun) -> ok when
+      StandaloneFun :: horus_fun().
+%% @doc Unloads the given standalone function underlying module.
+%%
+%% @private
+
+unload_standalone_fun(#horus_fun{module = Module}) ->
+    Lock = {{horus, load, Module}, self()},
+    global:set_lock(Lock, [node()]),
+    try
+        _ = code:delete(Module),
+        _ = code:purge(Module),
+        ?assertNot(horus_utils:is_module_loaded(Module)),
+        ok
+    after
+        global:del_lock(Lock, [node()])
+    end;
+unload_standalone_fun(Function) when is_function(Function) ->
+    ok.
 
 -spec to_fun(StandaloneFun) -> Fun when
       StandaloneFun :: horus_fun(),

--- a/src/horus_fun.hrl
+++ b/src/horus_fun.hrl
@@ -15,7 +15,7 @@
 %% IMPORTANT: When adding or removing fields to this record, be sure to update
 %% `include/horus.hrl'!
 -record(horus_fun, {module :: module(),
-                    beam :: binary(),
+                    beam :: binary() | tuple(),
                     arity :: arity(),
                     literal_funs :: [horus:horus_fun()],
                     fun_name_mapping :: horus:fun_name_mapping(),

--- a/test/lazy_compilation.erl
+++ b/test/lazy_compilation.erl
@@ -1,0 +1,63 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright © 2026 Broadcom. All Rights Reserved. The term "Broadcom"
+%% refers to Broadcom Inc. and/or its subsidiaries.
+%%
+
+-module(lazy_compilation).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-include("include/horus.hrl").
+-include("test/helpers.hrl").
+
+immediate_compilation_works_test() ->
+    Mod = arbitrary_mod,
+    Fun = fun Mod:min/2,
+    Args = [2, 3],
+    Options = #{lazy_compilation => false},
+    StandaloneFun = horus:to_standalone_fun(Fun, Options),
+
+    ?assertNot(horus:is_standalone_fun_loaded(StandaloneFun)),
+    ?assert(?IS_HORUS_STANDALONE_FUN(StandaloneFun)),
+    ?assertNot(horus:uses_lazy_compilation(StandaloneFun)),
+    ?assertEqual(2, horus:exec(StandaloneFun, Args)),
+    horus:unload_standalone_fun(StandaloneFun).
+
+lazy_compilation_works_test() ->
+    Mod = arbitrary_mod,
+    Fun = fun Mod:min/2,
+    Args = [2, 3],
+    Options = #{lazy_compilation => true},
+    StandaloneFun = horus:to_standalone_fun(Fun, Options),
+
+    ?assertNot(horus:is_standalone_fun_loaded(StandaloneFun)),
+    ?assert(?IS_HORUS_STANDALONE_FUN(StandaloneFun)),
+    ?assert(horus:uses_lazy_compilation(StandaloneFun)),
+    ?assertEqual(2, horus:exec(StandaloneFun, Args)),
+    horus:unload_standalone_fun(StandaloneFun).
+
+uses_immediate_compilation_by_default_test() ->
+    Mod = arbitrary_mod,
+    Fun = fun Mod:min/2,
+    Args = [2, 3],
+    StandaloneFun = horus:to_standalone_fun(Fun),
+
+    ?assertNot(horus:is_standalone_fun_loaded(StandaloneFun)),
+    ?assert(?IS_HORUS_STANDALONE_FUN(StandaloneFun)),
+    ?assertNot(horus:uses_lazy_compilation(StandaloneFun)),
+    ?assertEqual(2, horus:exec(StandaloneFun, Args)),
+    horus:unload_standalone_fun(StandaloneFun).
+
+lazy_compilation_does_not_affect_regular_funs_test() ->
+    Fun = fun lists:min/1,
+    List = [2, 3],
+    StandaloneFun = horus:to_standalone_fun(Fun),
+
+    ?assertNot(horus:is_standalone_fun_loaded(StandaloneFun)),
+    ?assertNot(?IS_HORUS_STANDALONE_FUN(StandaloneFun)),
+    ?assertNot(horus:uses_lazy_compilation(StandaloneFun)),
+    ?assertEqual(2, horus:exec(StandaloneFun, [List])),
+    horus:unload_standalone_fun(StandaloneFun).


### PR DESCRIPTION
## Why

By default, a standalone function is compiled at extraction time. The returned standalone function can be executed right away and it doesn't depend on any compiler wherever it is executed.

However, if the Erlang node that executes the standalone function runs an older version of Erlant compared to the node that extracted and compiled that function, the execution might crash becaue it would fail to load the module.

This is the case for a standalone function extracted on an Erlang/OTP 28 node but executed on an Erlang/OTP 27 node because the Atom table format in the beam file changed (atoms are UTF-8-encoded starting with the Erlang/OTP 28 compiler).

## How

To reduce the risk of this error, the compilation can be deferred to execution time. This is done by setting the `lazy_compilation` option to true when calling `horus:to_standalone_fun/2`.

The returned standalone function will contain the uncompiled assembly instead of the compiled beam. `horus:exec/2` will compile this assembly before loading and running the module as usual.

Note that an older version of Horus will crash trying to execute a standalone function using lazy compilation.

Also, the risk of incompatibility is not entirely resolved: if the new compiler supports assembly instructions that are not understood by the old runtime, the execution will still fail.

**V2**: Add a function to check if the module behind a standalone function is loaded and another function to unload it. This is useful in test cases of lazy compilation to ensure each test case is not polluted by a previously loaded standalone function.