### PR TITLE
test/erlang_blocks: Silence warning when testing `catch` explicitly

### DIFF
--- a/test/erlang_blocks.erl
+++ b/test/erlang_blocks.erl
@@ -12,6 +12,10 @@
 -feature(maybe_expr,enable).
 -endif.
 
+-if(?OTP_RELEASE >= 29).
+-compile(nowarn_deprecated_catch).
+-endif.
+
 -include_lib("eunit/include/eunit.hrl").
 
 -include("test/helpers.hrl").


### PR DESCRIPTION
## Why

The use of `catch` was deprecated a long time ago (I was not aware of that) and the Erlang/OTP 29 compiler starts to emit warnings about its use.

However, Horus has a testcase that tests the extraction of code using `catch`. We can't replace the `catch` operator by a try/catch block in this case because it would defeat the purpose of the test.

## How

Disable this specific warning in the testsuite.