### PR TITLE
horus: Support asm format from Erlang/OTP 29's compiler

### DIFF
--- a/.github/workflows/test-and-release.yaml
+++ b/.github/workflows/test-and-release.yaml
@@ -9,7 +9,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  REBAR_VERSION: '3.25.1'
+  REBAR_VERSION: '3.27.0'
   LATEST_ERLANG_VERSION: '28'
 
 jobs:

--- a/.github/workflows/test-job.yaml
+++ b/.github/workflows/test-job.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        otp_version: ['26', '27', '28']
+        otp_version: ['26', '27', '28', '29']
         os: [ubuntu-latest, windows-latest]
 
     steps:

--- a/.github/workflows/test-job.yaml
+++ b/.github/workflows/test-job.yaml
@@ -52,7 +52,7 @@ jobs:
         run: rebar3 as test covertool generate
 
       - name: Upload code coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: _build/test/covertool/horus.covertool.xml

--- a/rebar.config
+++ b/rebar.config
@@ -46,13 +46,7 @@
 
 {profiles,
  [{test,
-   [{deps, [%% FIXME: We need to add `cth_readable' as a dependency and an
-            %% extra app for Dialyzer. That's because Rebar is using that
-            %% application to override `ct:pal()' and Dialyzer complains it
-            %% doesn't know this application.
-            cth_readable]},
-    {dialyzer, [{plt_extra_apps, [common_test,
-                                  cth_readable, %% <-- See comment above.
+   [{dialyzer, [{plt_extra_apps, [common_test,
                                   edoc,
                                   eunit,
                                   inets,

--- a/src/horus.erl
+++ b/src/horus.erl
@@ -767,13 +767,28 @@ should_generate_module_info_functions(#state{options = Options}) ->
       Beam :: binary().
 
 compile(Asm) when is_tuple(Asm) ->
+    Asm1 = case does_compiler_support_native_records() of
+               true ->
+                   %% With the introduction of native records in Erlang/OTP 29,
+                   %% the format of the assembly tuple changed: it has a new
+                   %% element added to the fourth position, beam annotations.
+                   %%
+                   %% If the local compiler supports native records, we have to
+                   %% convert the 5-elements tuple to the 6-elements tuple with
+                   %% empty beam annotations.
+                   Anno = #{},
+                   {ModuleName, Exports, Attributes, Functions, Labels} = Asm,
+                   {ModuleName, Exports, Attributes, Anno, Functions, Labels};
+               false ->
+                   Asm
+           end,
     CompilerOptions = [from_asm,
                        binary,
                        warnings_as_errors,
                        return_errors,
                        return_warnings,
                        deterministic],
-    case compile:forms(Asm, CompilerOptions) of
+    case compile:forms(Asm1, CompilerOptions) of
         {ok, _Module, Beam, []} -> Beam;
         Error                   -> handle_compilation_error(Asm, Error)
     end;
@@ -787,6 +802,34 @@ compile(AbstractCode) when is_list(AbstractCode) ->
         {ok, _Module, Beam, []} -> Beam;
         Error                   -> handle_compilation_error(AbstractCode, Error)
     end.
+
+does_compiler_support_native_records() ->
+    Vsn = get_compiler_version(),
+    case Vsn of
+        [Maj | _] when Maj >= 10 ->
+            true;
+        _ ->
+            OTPRel = get_otp_release(),
+            case OTPRel of
+                _ when OTPRel >= 29 -> true;
+                _                   -> false
+            end
+    end.
+
+get_compiler_version() ->
+    case application:load(compiler) of
+        ok                           -> ok;
+        {error, {already_loaded, _}} -> ok
+    end,
+    {ok, Vsn0} = application:get_key(compiler, vsn),
+    Vsn1 = string:split(Vsn0, ".", all),
+    Vsn2 = [list_to_integer(I) || I <- Vsn1],
+    Vsn2.
+
+get_otp_release() ->
+    OTPRel0 = erlang:system_info(otp_release),
+    OTPRel1 = list_to_integer(OTPRel0),
+    OTPRel1.
 
 handle_compilation_error(
   Asm,
@@ -1568,6 +1611,11 @@ pass1_process_instructions(
         false ->
             pass1_process_instructions(Rest, State, Result)
     end;
+pass1_process_instructions(
+  [{line, Args} = Instruction | Rest],
+  State,
+  Result) when is_list(Args) ->
+    pass1_process_instructions(Rest, State, [Instruction | Result]);
 pass1_process_instructions(
   [{executable_line, Index, _Unknown} = Instruction | Rest],
   #state{lines_in_progress = Lines} = State,

--- a/test/compiling.erl
+++ b/test/compiling.erl
@@ -52,7 +52,7 @@ can_compile_asm_test() ->
 
     ?assertError(
        ?horus_exception(compilation_failure, #{}),
-       horus:compile({})).
+       horus:compile({a, b, c, d, e})).
 
 can_compile_abtract_code_test() ->
     Mod = arbitrary_mod,


### PR DESCRIPTION
## Why

With the introduction of native records in Erlang/OTP 29, the format of the assembly tuple changed: it has a new element added to the fourth position, beam annotations.

## How

If the local compiler supports native records, we have to convert the 5-elements tuple to the 6-elements tuple with empty beam annotations.

Note that we use the version of the compiler to determine which format to use. The documentation states that the compiler version of Erlang/OTP 29.0 is 10.0.0, but as of this writing, it is 9.x in their master branch. We use the OTP release as a fallback.

Fixes #38, #39.