### PR TITLE
horus: Pass undocumented compiler options to get Erlang 26-compatible Beam modules

### DIFF
--- a/.github/workflows/compatibility-job.yaml
+++ b/.github/workflows/compatibility-job.yaml
@@ -1,0 +1,74 @@
+name: Single compatibility job
+
+on:
+  workflow_call:
+    inputs:
+      rebar_version:
+        required: true
+        type: string
+    secrets:
+      CODECOV_TOKEN:
+        required: true
+
+jobs:
+  test:
+    name: "Erlang/OTP ${{ matrix.from_otp_version }} -> ${{ matrix.to_otp_version }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        from_otp_version: ['26', '27', '28', '29']
+        to_otp_version:   ['26', '27', '28', '29']
+        exclude:
+          - { from_otp_version: '26', to_otp_version: '26' }
+          - { from_otp_version: '27', to_otp_version: '27' }
+          - { from_otp_version: '28', to_otp_version: '28' }
+          - { from_otp_version: '29', to_otp_version: '29' }
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Erlang/OTP ${{ matrix.from_otp_version }}
+        uses: erlef/setup-beam@v1
+        id: install-erlang-1
+        with:
+          otp-version: ${{ matrix.from_otp_version }}
+          rebar3-version: ${{ inputs.rebar_version }}
+
+      - name: Record Erlang/OTP installed version (1)
+        run: erl -noinput -eval 'io:format("~s~n", [erlang:system_info(otp_release)]), halt().' > erlang-version-1.txt
+
+      - name: Compile with Erlang/OTP ${{ matrix.from_otp_version }}
+        run: rebar3 compile
+
+      - name: Generate module
+        run: ./.github/workflows/compatibility_test.escript generate standalone_function.bin
+
+      - name: Clean workspace
+        run: |
+          rm -rf ./_build
+
+          rm -rf ~/.cache/rebar3
+          rm -rf ~/work/_temp/.setup-beam
+
+      - name: Install Erlang/OTP ${{ matrix.to_otp_version }}
+        uses: erlef/setup-beam@v1
+        id: install-erlang-2
+        with:
+          otp-version: ${{ matrix.to_otp_version }}
+          rebar3-version: ${{ inputs.rebar_version }}
+
+      - name: Record Erlang/OTP installed version (2)
+        run: erl -noinput -eval 'io:format("~s~n", [erlang:system_info(otp_release)]), halt().' > erlang-version-2.txt
+
+      - name: Ensure second Erlang/OTP version differs from first
+        run: |
+          set -x
+          ! diff -u erlang-version-1.txt erlang-version-2.txt
+          ! cmp -s erlang-version-1.txt erlang-version-2.txt
+
+      - name: Compile with Erlang/OTP ${{ matrix.to_otp_version }}
+        run: rebar3 compile
+
+      - name: Run generated module
+        run: ./.github/workflows/compatibility_test.escript run standalone_function.bin

--- a/.github/workflows/compatibility_test.erl
+++ b/.github/workflows/compatibility_test.erl
@@ -1,0 +1,47 @@
+-module(compatibility_test).
+
+-export([generate/1,
+         run/1]).
+
+-record(my_record, { field }).
+
+generate(Filename) ->
+    {ok, _} = application:ensure_all_started(horus),
+
+    Fun = fun() ->
+                  %% Test maps.
+                  Map1 = #{field => value1},
+                  Map2 = Map1#{field => value2},
+                  #{field := value2} = Map2,
+
+                  %% Test records.
+                  Record1 = #my_record{field = value1},
+                  Record2 = Record1#my_record{field = value2},
+                  true = (
+                    is_tuple(Record2) andalso
+                    element(#my_record.field, Record2) =:= value2),
+
+                  %% Test case blocks.
+                  case node() of
+                      some_node -> throw(impossible);
+                      _         -> ok
+                  end,
+
+                  %% Test message send/receive.
+                  Pid = self(),
+                  Pid ! message,
+                  receive message -> ok after 1000 -> throw(receive_timeout) end,
+
+                  file:delete(Filename),
+                  io:format("Success!~n", [])
+          end,
+    StandaloneFun = horus:to_standalone_fun(Fun),
+
+    Bin = list_to_binary(io_lib:format("~p.~n", [StandaloneFun])),
+    ok = file:write_file(Filename, Bin),
+    ok.
+
+run(Filename) ->
+    {ok, _} = application:ensure_all_started(horus),
+    {ok, [StandaloneFun]} = file:consult(Filename),
+    horus:exec(StandaloneFun, []).

--- a/.github/workflows/compatibility_test.escript
+++ b/.github/workflows/compatibility_test.escript
@@ -1,0 +1,23 @@
+#!/usr/bin/env escript
+%%! -pa .github/workflows -pa _build/default/lib/horus/ebin
+
+-define(OUTPUT_DIR, ".github/workflows").
+-define(MOD_SOURCE, ?OUTPUT_DIR "/compatibility_test.erl").
+
+main(["generate", Filename]) ->
+    Mod = compile(),
+    ok = Mod:generate(Filename),
+    ok;
+main(["run", Filename]) ->
+    Mod = compile(),
+    ok = Mod:run(Filename),
+    ok.
+
+compile() ->
+    CompileOptions = [report,
+                      return_errors,
+                      return_warnings,
+                      debug_info,
+                      {outdir, ?OUTPUT_DIR}],
+    {ok, Mod, []} = compile:file(?MOD_SOURCE, CompileOptions),
+    Mod.

--- a/.github/workflows/test-and-release.yaml
+++ b/.github/workflows/test-and-release.yaml
@@ -67,12 +67,22 @@ jobs:
       - name: Dialyzer
         run: rebar3 clean && rebar3 as test dialyzer
 
+  compatibility:
+    name: Compatibility test
+    needs: env_to_output
+    uses: ./.github/workflows/compatibility-job.yaml
+    with:
+      rebar_version: ${{ needs.env_to_output.outputs.REBAR_VERSION }}
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
   build_docs:
     name: Generate docs
     runs-on: ubuntu-latest
     needs:
       - test
       - dialyzer
+      - compatibility
 
     steps:
       - uses: actions/checkout@v6
@@ -125,6 +135,7 @@ jobs:
     needs:
       - test
       - dialyzer
+      - compatibility
       - build_docs
     if: github.repository == 'rabbitmq/horus' && (startsWith(github.ref, 'refs/tags/v0') || startsWith(github.ref, 'refs/tags/v1') || startsWith(github.ref, 'refs/tags/v2') || startsWith(github.ref, 'refs/tags/v3') || startsWith(github.ref, 'refs/tags/v4') || startsWith(github.ref, 'refs/tags/v5') || startsWith(github.ref, 'refs/tags/v6') || startsWith(github.ref, 'refs/tags/v7') || startsWith(github.ref, 'refs/tags/v8') || startsWith(github.ref, 'refs/tags/v9'))
 

--- a/src/horus.erl
+++ b/src/horus.erl
@@ -787,7 +787,13 @@ compile(Asm) when is_tuple(Asm) ->
                        warnings_as_errors,
                        return_errors,
                        return_warnings,
-                       deterministic],
+                       deterministic,
+
+                       %% We set undocumented compiler options to make sure the
+                       %% compiler generates a Beam module compatible with
+                       %% Erlang/OTP 26 and 27.
+                       no_long_atoms,
+                       compressed_literals],
     case compile:forms(Asm1, CompilerOptions) of
         {ok, _Module, Beam, []} -> Beam;
         Error                   -> handle_compilation_error(Asm, Error)
@@ -797,7 +803,13 @@ compile(AbstractCode) when is_list(AbstractCode) ->
                        warnings_as_errors,
                        return_errors,
                        return_warnings,
-                       deterministic],
+                       deterministic,
+
+                       %% We set undocumented compiler options to make sure the
+                       %% compiler generates a Beam module compatible with
+                       %% Erlang/OTP 26 and 27.
+                       no_long_atoms,
+                       compressed_literals],
     case compile:forms(AbstractCode, CompilerOptions) of
         {ok, _Module, Beam, []} -> Beam;
         Error                   -> handle_compilation_error(AbstractCode, Error)


### PR DESCRIPTION
## Why

When Horus is used on an Erlang/OTP 28+ node to generate a standalone function, but this standalone function is executed on an Erlang/OTP 27 or earlier version, the standalone function's module fails to load because starting from Erlang/OTP 28, the *Atom Table* and the *Literal Table* use a different format.

The *Atom Table* uses a "long atom" encoding to allow Unicode-encoded atoms longer than 64 bytes.

The *Literal Table* is no longer compressed.

## How

The Erlang compiler supports undocumented options to tell it to use the previous format compatible with Erlang/OTP 27 and earlier.

For instance, this fixes the use of Khepri in mixed-version clusters.